### PR TITLE
Display `No timestamps found.` for videos without timestamps

### DIFF
--- a/src/discord-in-c/test2.c
+++ b/src/discord-in-c/test2.c
@@ -1151,6 +1151,9 @@ void timestamps_command(voice_gateway_t *vgt, discord_t *dis,
       strcat(message_body, line_buf);
     }
 
+    if (!cJSON_GetArraySize(timestamp_json_arr))
+      strcat(message_body, "\\nNo timestamps found.");
+
     cJSON_Delete(timestamp_json_arr);
 
     // print the final message


### PR DESCRIPTION
Fixes #22 :)